### PR TITLE
Shorten (simplify?) __init__ in SIZR class

### DIFF
--- a/sizr.py
+++ b/sizr.py
@@ -7,9 +7,10 @@ Z' = rho*I - alpha*S*Z
 R' = delta_S*S + delta_I*I + alpha*S*Z
 """
 
-import numpy as np 
+import numpy as np
 from matplotlib import pyplot as plt
 from ODESolver import ForwardEuler
+
 
 class SIZR:
     def __init__(
@@ -21,49 +22,27 @@ class SIZR:
         initial value:  S0, I0, Z0, R0
         """
 
-        if isinstance(sigma, (float, int)):
-            self.sigma = lambda t: sigma
-        elif callable(sigma):
-            self.sigma = sigma
-
-        if isinstance(beta, (float, int)):
-            self.beta = lambda t: beta
-        elif callable(beta):
-            self.beta = beta
-
-        if isinstance(rho, (float, int)):
-            self.rho = lambda t: rho
-        elif callable(rho):
-            self.rho = rho
-
-        if isinstance(delta_S, (float, int)):
-            self.delta_S = lambda t: delta_S
-        elif callable(delta_S):
-            self.delta_S = delta_S
-
-        if isinstance(delta_I, (float, int)):
-            self.delta_I = lambda t: delta_I
-        elif callable(delta_I):
-            self.delta_I = delta_I
-
-        if isinstance(alpha, (float, int)):
-            self.alpha = lambda t: alpha
-        elif callable(alpha):
-            self.alpha = alpha
+        for name, argument in locals().items():
+            if name not in ('self', 'S0', 'I0', 'R0', 'Z0'):
+                if isinstance(argument, (float, int)):
+                    setattr(self, name, lambda self, value=argument: value)
+                elif callable(argument):
+                    setattr(self, name, argument)
 
         self.initial_conditions = [S0, I0, Z0, R0]
 
     def __call__(self, u, t):
         """RHS of system of ODEs"""
 
-        S, I, Z, _ = u 
+        S, I, Z, _ = u
 
         return np.asarray([
             self.sigma(t) - self.beta(t)*S*Z - self.delta_S(t)*S,
             self.beta(t)*S*Z - self.rho(t)*I - self.delta_I(t)*I,
             self.rho(t)*I - self.alpha(t)*S*Z,
-            self.delta_S(t)*S + self.delta_I(t)*I + self.alpha(t)*I 
+            self.delta_S(t)*S + self.delta_I(t)*I + self.alpha(t)*I
         ])
+
 
 if __name__ == "__main__":
 
@@ -86,8 +65,8 @@ if __name__ == "__main__":
 
     beta = lambda t: 0.03 if t < 4 else (0.0012 if t > 4 and t < 28 else 0)
     alpha = lambda t: 0 if t < 4 else (0.0016 if t > 4 and t < 28 else 0.05)
-    sigma = lambda t: 20 if t < 4 else (2 if t > 4 and t < 28  else 0)
-    rho = 1
+    sigma = lambda t: 20 if t < 4 else (2 if t > 4 and t < 28 else 0)
+    rho = 1.0
     delta_I = lambda t: 0 if t < 4 else (0.014 if t > 4 and t < 28 else 0.05)
     delta_S = lambda t: 0 if t < 28 else 0.007
 
@@ -108,7 +87,7 @@ if __name__ == "__main__":
     )
     solver = ForwardEuler(zombie_model)
     solver.set_initial_conditions(zombie_model.initial_conditions)
-    
+
     time_steps = np.linspace(0, 33, 1001)
     u, t = solver.solve(time_steps)
 

--- a/sizr.py
+++ b/sizr.py
@@ -7,10 +7,9 @@ Z' = rho*I - alpha*S*Z
 R' = delta_S*S + delta_I*I + alpha*S*Z
 """
 
-import numpy as np
+import numpy as np 
 from matplotlib import pyplot as plt
 from ODESolver import ForwardEuler
-
 
 class SIZR:
     def __init__(
@@ -34,15 +33,14 @@ class SIZR:
     def __call__(self, u, t):
         """RHS of system of ODEs"""
 
-        S, I, Z, _ = u
+        S, I, Z, _ = u 
 
         return np.asarray([
             self.sigma(t) - self.beta(t)*S*Z - self.delta_S(t)*S,
             self.beta(t)*S*Z - self.rho(t)*I - self.delta_I(t)*I,
             self.rho(t)*I - self.alpha(t)*S*Z,
-            self.delta_S(t)*S + self.delta_I(t)*I + self.alpha(t)*I
+            self.delta_S(t)*S + self.delta_I(t)*I + self.alpha(t)*I 
         ])
-
 
 if __name__ == "__main__":
 
@@ -65,8 +63,8 @@ if __name__ == "__main__":
 
     beta = lambda t: 0.03 if t < 4 else (0.0012 if t > 4 and t < 28 else 0)
     alpha = lambda t: 0 if t < 4 else (0.0016 if t > 4 and t < 28 else 0.05)
-    sigma = lambda t: 20 if t < 4 else (2 if t > 4 and t < 28 else 0)
-    rho = 1.0
+    sigma = lambda t: 20 if t < 4 else (2 if t > 4 and t < 28  else 0)
+    rho = 1
     delta_I = lambda t: 0 if t < 4 else (0.014 if t > 4 and t < 28 else 0.05)
     delta_S = lambda t: 0 if t < 28 else 0.007
 
@@ -87,7 +85,7 @@ if __name__ == "__main__":
     )
     solver = ForwardEuler(zombie_model)
     solver.set_initial_conditions(zombie_model.initial_conditions)
-
+    
     time_steps = np.linspace(0, 33, 1001)
     u, t = solver.solve(time_steps)
 


### PR DESCRIPTION
Suggestion for shortening the constructor of the `SIZR` class using some `setattr` logic instead of copy-pasting 30 lines of code. Uses `locals()` with `self` and the initial conditions excluded to fish out the names of the arguments in string form, and then lambdifies any `int` or `float` arguments. 

#### Explanation for funky `lambda` declaration:
Note that simply using 
```python
setattr(self, name, lambda t: argument)  # line 27
```
does not work because of the local `argument` variable falling out of scope when the loop in line 24 continues, see e.g. [this](https://stackoverflow.com/a/33134889/4179419). This would result in any lambda created in this way always returning the value of the last argument given to the `__init__` function (here `R0`).

Creating the anonymous function with a default argument instead sets the default **at the time of the lambda declaration**, retaining the value of the scoped `argument` variable inside the anonymous function after the loop continues (TIL).  